### PR TITLE
Add TTS/SFX toggles to settings and remove Reset DB schema button

### DIFF
--- a/App.js
+++ b/App.js
@@ -58,6 +58,8 @@ const DEFAULT_TTS_PITCH = 1.0;
 const DEFAULT_TTS_VOICE = '';
 const DEFAULT_TTS_PROVIDER = TTS_PROVIDER_SYSTEM;
 const DEFAULT_THEME = 'light';
+const DEFAULT_TTS_ENABLED = true;
+const DEFAULT_SFX_ENABLED = true;
 const QUIZ_FEEDBACK_DELAY_MS = 900;
 const QUIZ_CORRECT_SOUND_DURATION_MS = 600;
 const QUIZ_WRONG_SOUND_DURATION_MS = 750;
@@ -198,6 +200,8 @@ function AppShell({ storage }) {
   const [ttsPitch, setTtsPitch] = useState(DEFAULT_TTS_PITCH);
   const [ttsVoice, setTtsVoice] = useState(DEFAULT_TTS_VOICE);
   const [ttsProvider, setTtsProvider] = useState(DEFAULT_TTS_PROVIDER);
+  const [ttsEnabled, setTtsEnabled] = useState(DEFAULT_TTS_ENABLED);
+  const [sfxEnabled, setSfxEnabled] = useState(DEFAULT_SFX_ENABLED);
   const [theme, setTheme] = useState(DEFAULT_THEME);
   const [reviewScreenKey, setReviewScreenKey] = useState(0);
   const [debugCountryFilter, setDebugCountryFilter] = useState('all');
@@ -276,11 +280,15 @@ function AppShell({ storage }) {
       voice: DEFAULT_TTS_VOICE,
       provider: DEFAULT_TTS_PROVIDER,
       theme: DEFAULT_THEME,
+      ttsEnabled: DEFAULT_TTS_ENABLED,
+      sfxEnabled: DEFAULT_SFX_ENABLED,
     }).then((settings) => {
       setTtsRate(settings.rate);
       setTtsPitch(settings.pitch);
       setTtsVoice(settings.voice || DEFAULT_TTS_VOICE);
       setTtsProvider(settings.provider || DEFAULT_TTS_PROVIDER);
+      setTtsEnabled(settings.ttsEnabled ?? DEFAULT_TTS_ENABLED);
+      setSfxEnabled(settings.sfxEnabled ?? DEFAULT_SFX_ENABLED);
       setTheme(settings.theme);
     });
   }, [storage]);
@@ -640,6 +648,10 @@ function AppShell({ storage }) {
         return Promise.resolve();
       }
 
+      if (!ttsEnabled) {
+        return Promise.resolve();
+      }
+
       const tasks = [];
 
       if (quizItem.promptField === 'front' && quizItem.promptText) {
@@ -676,7 +688,7 @@ function AppShell({ storage }) {
 
       return Promise.allSettled(tasks);
     },
-    [effectiveTtsPitch, effectiveTtsRate, ttsProvider, ttsVoice]
+    [effectiveTtsPitch, effectiveTtsRate, ttsEnabled, ttsProvider, ttsVoice]
   );
 
   const startQuiz = useCallback(async () => {
@@ -1002,6 +1014,10 @@ function AppShell({ storage }) {
 
   const speakText = useCallback(
     (text, overrides = {}) => {
+      if (!ttsEnabled) {
+        return Promise.resolve(null);
+      }
+
       const language = overrides.language ?? getSpeechLanguage(text);
 
       return speakWithTts({
@@ -1029,7 +1045,7 @@ function AppShell({ storage }) {
         return result;
       });
     },
-    [currentTtsProviderStatus.effectiveProvider, effectiveTtsPitch, effectiveTtsRate, ttsProvider, ttsVoice]
+    [currentTtsProviderStatus.effectiveProvider, effectiveTtsPitch, effectiveTtsRate, ttsEnabled, ttsProvider, ttsVoice]
   );
 
   const speakFrontText = useCallback(
@@ -1065,6 +1081,10 @@ function AppShell({ storage }) {
   );
 
   const playFeedbackSound = async (isCorrect) => {
+    if (!sfxEnabled) {
+      return null;
+    }
+
     const requestId = feedbackSoundRequestRef.current + 1;
     feedbackSoundRequestRef.current = requestId;
 
@@ -1086,12 +1106,14 @@ function AppShell({ storage }) {
       player.play();
       return requestId;
     } catch (error) {
-      await speakWithTts({
-        provider: TTS_PROVIDER_SYSTEM,
-        text: isCorrect ? 'Correct' : 'Incorrect',
-        rate: 0.95,
-        pitch: isCorrect ? 1.0 : 0.85,
-      });
+      if (ttsEnabled) {
+        await speakWithTts({
+          provider: TTS_PROVIDER_SYSTEM,
+          text: isCorrect ? 'Correct' : 'Incorrect',
+          rate: 0.95,
+          pitch: isCorrect ? 1.0 : 0.85,
+        });
+      }
       return requestId;
     }
   };
@@ -2173,6 +2195,43 @@ function AppShell({ storage }) {
         <Text style={[styles.mutedText, { color: colors.secondaryText }]}>Adjust speech playback to match the way you want cards to sound.</Text>
 
         <View style={styles.settingsGroup}>
+          <Text style={[styles.settingsLabel, { color: colors.primaryText }]}>Sound types</Text>
+          <View style={styles.filterRow}>
+            {[
+              {
+                key: 'tts_enabled',
+                label: 'TTS',
+                active: ttsEnabled,
+                onPress: () => updateSpeechSetting('tts_enabled', !ttsEnabled, setTtsEnabled),
+              },
+              {
+                key: 'sfx_enabled',
+                label: 'SFX',
+                active: sfxEnabled,
+                onPress: () => updateSpeechSetting('sfx_enabled', !sfxEnabled, setSfxEnabled),
+              },
+            ].map((option) => (
+              <Pressable
+                key={option.key}
+                style={[
+                  styles.filterChip,
+                  { backgroundColor: colors.softSurface, borderColor: colors.border },
+                  option.active && { backgroundColor: colors.primaryText, borderColor: colors.primaryText },
+                ]}
+                onPress={option.onPress}
+              >
+                <Text style={[styles.filterChipText, { color: option.active ? colors.surface : colors.primaryText }]}>
+                  {option.label}: {option.active ? 'On' : 'Off'}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+          <Text style={[styles.mutedText, { color: colors.secondaryText }]}>
+            Turn spoken card audio and answer sound effects on or off independently.
+          </Text>
+        </View>
+
+        <View style={styles.settingsGroup}>
           <Text style={[styles.settingsLabel, { color: colors.primaryText }]}>Provider</Text>
           <View style={styles.filterRow}>
             {TTS_PROVIDER_OPTIONS.map((option) => {
@@ -2269,8 +2328,16 @@ function AppShell({ storage }) {
         )}
 
         <Pressable
-          style={[styles.secondaryButton, { backgroundColor: colors.surface, borderColor: colors.border }]}
+          style={[
+            styles.secondaryButton,
+            {
+              backgroundColor: colors.surface,
+              borderColor: colors.border,
+              opacity: ttsEnabled ? 1 : 0.55,
+            },
+          ]}
           onPress={() => speakFrontText(findSpeechPreviewText(cards))}
+          disabled={!ttsEnabled}
         >
           <Text style={[styles.secondaryButtonText, { color: colors.primaryText }]}>Preview speech</Text>
         </Pressable>
@@ -2300,9 +2367,6 @@ function AppShell({ storage }) {
         <Text style={[styles.mutedText, { color: colors.secondaryText }]}>Delete all sets, cards, and quiz history from this device.</Text>
         <Pressable style={[styles.dangerButton, { backgroundColor: colors.dangerSurface, borderColor: colors.dangerBorder }]} onPress={clearAllData}>
           <Text style={[styles.dangerButtonText, { color: colors.dangerText }]}>Clear all data</Text>
-        </Pressable>
-        <Pressable style={[styles.dangerButton, { backgroundColor: colors.dangerSurface, borderColor: colors.dangerBorder }]} onPress={resetDatabaseSchema}>
-          <Text style={[styles.dangerButtonText, { color: colors.dangerText }]}>Reset DB schema</Text>
         </Pressable>
       </View>
 

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -89,8 +89,8 @@ export async function saveQuizSession(db, selectedSetIds, answers) {
 
 export async function loadAppSettings(db, defaults) {
   const rows = await db.getAllAsync(
-    'SELECT key, value FROM app_settings WHERE key IN (?, ?, ?, ?, ?)',
-    ['tts_rate', 'tts_pitch', 'theme', 'tts_voice', 'tts_provider']
+    'SELECT key, value FROM app_settings WHERE key IN (?, ?, ?, ?, ?, ?, ?)',
+    ['tts_rate', 'tts_pitch', 'theme', 'tts_voice', 'tts_provider', 'tts_enabled', 'sfx_enabled']
   );
 
   const settingsMap = Object.fromEntries((rows ?? []).map((row) => [row.key, row.value]));
@@ -101,6 +101,8 @@ export async function loadAppSettings(db, defaults) {
     theme: settingsMap.theme || defaults.theme,
     voice: settingsMap.tts_voice || defaults.voice,
     provider: settingsMap.tts_provider || defaults.provider,
+    ttsEnabled: settingsMap.tts_enabled ? settingsMap.tts_enabled === 'true' : defaults.ttsEnabled,
+    sfxEnabled: settingsMap.sfx_enabled ? settingsMap.sfx_enabled === 'true' : defaults.sfxEnabled,
   };
 }
 

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -413,6 +413,8 @@ export function createWebStorage() {
         theme: store.appSettings.theme || defaults.theme,
         voice: store.appSettings.tts_voice || defaults.voice,
         provider: store.appSettings.tts_provider || defaults.provider,
+        ttsEnabled: store.appSettings.tts_enabled ? store.appSettings.tts_enabled === 'true' : defaults.ttsEnabled,
+        sfxEnabled: store.appSettings.sfx_enabled ? store.appSettings.sfx_enabled === 'true' : defaults.sfxEnabled,
       };
     },
 


### PR DESCRIPTION
### Motivation
- Provide separate, persistent toggles for spoken TTS and answer SFX so users can enable/disable each sound type independently.
- Respect those preferences across app sessions and avoid playing or prefetching audio when disabled.
- Remove the highly-destructive `Reset DB schema` button from the settings danger zone to reduce accidental data loss.

### Description
- Add `DEFAULT_TTS_ENABLED` and `DEFAULT_SFX_ENABLED` and component state `ttsEnabled` / `sfxEnabled` in `App.js` and load/save these values from storage.
- Extend `loadAppSettings` in `src/lib/db.js` and `createWebStorage` in `src/lib/storage.js` to include `tts_enabled` and `sfx_enabled` keys and return `ttsEnabled` / `sfxEnabled` flags.
- Wire settings into runtime behavior so TTS prefetch/playback is skipped when `ttsEnabled` is false and quiz feedback sounds are suppressed when `sfxEnabled` is false (with spoken fallback only if TTS remains enabled).
- Add a new “Sound types” settings group with TTS/SFX toggle chips and disable the speech preview button when TTS is off, and remove the `Reset DB schema` button from the Danger zone UI.

### Testing
- Ran unit/integration tests with `npm test`, all suites passed (`4` test suites, `20` tests). 
- Ran a web export with `npm run build:web`, which completed and produced the web `dist` bundle successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf229094d8832990031aa0020ccac5)