### PR TITLE
Add granular TTS/SFX controls, volumes, and auto-play toggle

### DIFF
--- a/App.js
+++ b/App.js
@@ -53,6 +53,7 @@ const DB_NAME = 'flashcards.db';
 const QUIZ_SIZE_OPTIONS = [10, 20, 30];
 const TTS_RATE_OPTIONS = [0.3, 0.6, 0.9];
 const TTS_PITCH_OPTIONS = [0.8, 1.0, 1.2];
+const VOLUME_OPTIONS = [0.25, 0.5, 0.75, 1.0];
 const DEFAULT_TTS_RATE = 0.9;
 const DEFAULT_TTS_PITCH = 1.0;
 const DEFAULT_TTS_VOICE = '';
@@ -60,6 +61,9 @@ const DEFAULT_TTS_PROVIDER = TTS_PROVIDER_SYSTEM;
 const DEFAULT_THEME = 'light';
 const DEFAULT_TTS_ENABLED = true;
 const DEFAULT_SFX_ENABLED = true;
+const DEFAULT_TTS_VOLUME = 1.0;
+const DEFAULT_SFX_VOLUME = 1.0;
+const DEFAULT_AUTO_PLAY_TTS_ENABLED = true;
 const QUIZ_FEEDBACK_DELAY_MS = 900;
 const QUIZ_CORRECT_SOUND_DURATION_MS = 600;
 const QUIZ_WRONG_SOUND_DURATION_MS = 750;
@@ -201,7 +205,10 @@ function AppShell({ storage }) {
   const [ttsVoice, setTtsVoice] = useState(DEFAULT_TTS_VOICE);
   const [ttsProvider, setTtsProvider] = useState(DEFAULT_TTS_PROVIDER);
   const [ttsEnabled, setTtsEnabled] = useState(DEFAULT_TTS_ENABLED);
+  const [ttsVolume, setTtsVolume] = useState(DEFAULT_TTS_VOLUME);
   const [sfxEnabled, setSfxEnabled] = useState(DEFAULT_SFX_ENABLED);
+  const [sfxVolume, setSfxVolume] = useState(DEFAULT_SFX_VOLUME);
+  const [autoPlayTtsEnabled, setAutoPlayTtsEnabled] = useState(DEFAULT_AUTO_PLAY_TTS_ENABLED);
   const [theme, setTheme] = useState(DEFAULT_THEME);
   const [reviewScreenKey, setReviewScreenKey] = useState(0);
   const [debugCountryFilter, setDebugCountryFilter] = useState('all');
@@ -281,14 +288,20 @@ function AppShell({ storage }) {
       provider: DEFAULT_TTS_PROVIDER,
       theme: DEFAULT_THEME,
       ttsEnabled: DEFAULT_TTS_ENABLED,
+      ttsVolume: DEFAULT_TTS_VOLUME,
       sfxEnabled: DEFAULT_SFX_ENABLED,
+      sfxVolume: DEFAULT_SFX_VOLUME,
+      autoPlayTtsEnabled: DEFAULT_AUTO_PLAY_TTS_ENABLED,
     }).then((settings) => {
       setTtsRate(settings.rate);
       setTtsPitch(settings.pitch);
       setTtsVoice(settings.voice || DEFAULT_TTS_VOICE);
       setTtsProvider(settings.provider || DEFAULT_TTS_PROVIDER);
       setTtsEnabled(settings.ttsEnabled ?? DEFAULT_TTS_ENABLED);
+      setTtsVolume(settings.ttsVolume ?? DEFAULT_TTS_VOLUME);
       setSfxEnabled(settings.sfxEnabled ?? DEFAULT_SFX_ENABLED);
+      setSfxVolume(settings.sfxVolume ?? DEFAULT_SFX_VOLUME);
+      setAutoPlayTtsEnabled(settings.autoPlayTtsEnabled ?? DEFAULT_AUTO_PLAY_TTS_ENABLED);
       setTheme(settings.theme);
     });
   }, [storage]);
@@ -738,7 +751,7 @@ function AppShell({ storage }) {
   const progressText = quizTargetCount ? `${Math.min(quizIndex + 1, quizTargetCount)} / ${quizTargetCount}` : '0 / 0';
 
   useEffect(() => {
-    if (screen !== 'quiz' || currentItem?.promptField !== 'front' || !currentItem?.promptText) {
+    if (screen !== 'quiz' || !autoPlayTtsEnabled || currentItem?.promptField !== 'front' || !currentItem?.promptText) {
       return undefined;
     }
 
@@ -749,7 +762,7 @@ function AppShell({ storage }) {
     }, delayMs);
 
     return () => clearTimeout(timeoutId);
-  }, [currentItem?.promptField, currentItem?.promptText, effectiveTtsPitch, effectiveTtsRate, screen]);
+  }, [autoPlayTtsEnabled, currentItem?.promptField, currentItem?.promptText, effectiveTtsPitch, effectiveTtsRate, screen]);
 
   useEffect(() => {
     if (screen !== 'quiz' || !currentItem) {
@@ -1027,6 +1040,7 @@ function AppShell({ storage }) {
         pitch: overrides.pitch ?? effectiveTtsPitch,
         language,
         voice: (overrides.voice ?? ttsVoice) || undefined,
+        volume: overrides.volume ?? ttsVolume,
       }).then((result) => {
         setDebugInfo((prev) => ({
           ...prev,
@@ -1045,7 +1059,7 @@ function AppShell({ storage }) {
         return result;
       });
     },
-    [currentTtsProviderStatus.effectiveProvider, effectiveTtsPitch, effectiveTtsRate, ttsEnabled, ttsProvider, ttsVoice]
+    [currentTtsProviderStatus.effectiveProvider, effectiveTtsPitch, effectiveTtsRate, ttsEnabled, ttsProvider, ttsVoice, ttsVolume]
   );
 
   const speakFrontText = useCallback(
@@ -1102,6 +1116,7 @@ function AppShell({ storage }) {
       }
 
       const player = isCorrect ? correctPlayer : wrongPlayer;
+      player.volume = sfxVolume;
       player.seekTo(0);
       player.play();
       return requestId;
@@ -1112,6 +1127,7 @@ function AppShell({ storage }) {
           text: isCorrect ? 'Correct' : 'Incorrect',
           rate: 0.95,
           pitch: isCorrect ? 1.0 : 0.85,
+          volume: ttsVolume,
         });
       }
       return requestId;
@@ -1120,7 +1136,7 @@ function AppShell({ storage }) {
 
   const playPostAnswerAudio = async (quizItem, isCorrect) => {
     const requestId = await playFeedbackSound(isCorrect);
-    if (!requestId || quizItem?.promptField !== 'back') {
+    if (!requestId || !autoPlayTtsEnabled || quizItem?.promptField !== 'back') {
       return;
     }
 
@@ -1428,12 +1444,14 @@ function AppShell({ storage }) {
                     </Text>
                   ) : null}
                 </View>
-                <Pressable
-                  style={[styles.listenMiniButton, { backgroundColor: colors.softAccent }]}
-                  onPress={() => speakFrontText(item.front)}
-                >
-                  <Text style={styles.listenMiniText}>🔊</Text>
-                </Pressable>
+                {ttsEnabled ? (
+                  <Pressable
+                    style={[styles.listenMiniButton, { backgroundColor: colors.softAccent }]}
+                    onPress={() => speakFrontText(item.front)}
+                  >
+                    <Text style={styles.listenMiniText}>🔊</Text>
+                  </Pressable>
+                ) : null}
               </View>
             ))}
           </View>
@@ -1479,7 +1497,7 @@ function AppShell({ storage }) {
             >
               {currentItem.promptText}
             </Text>
-            {currentItem.promptField === 'front' ? (
+            {ttsEnabled && currentItem.promptField === 'front' ? (
               <Pressable
                 style={[styles.listenMiniButton, { backgroundColor: colors.softAccent }]}
                 onPress={() => speakFrontText(currentItem.promptText)}
@@ -1525,7 +1543,7 @@ function AppShell({ storage }) {
                   >
                     {option}
                   </Text>
-                  {currentItem.promptField === 'back' && option !== QUIZ_DONT_KNOW_OPTION ? (
+                  {ttsEnabled && currentItem.promptField === 'back' && option !== QUIZ_DONT_KNOW_OPTION ? (
                     <Pressable
                       style={[styles.optionSoundButton, { backgroundColor: colors.softAccent, borderColor: colors.border }]}
                       onPress={(event) => {
@@ -2210,6 +2228,12 @@ function AppShell({ storage }) {
                 active: sfxEnabled,
                 onPress: () => updateSpeechSetting('sfx_enabled', !sfxEnabled, setSfxEnabled),
               },
+              {
+                key: 'tts_autoplay_enabled',
+                label: 'Auto-play TTS',
+                active: autoPlayTtsEnabled,
+                onPress: () => updateSpeechSetting('tts_autoplay_enabled', !autoPlayTtsEnabled, setAutoPlayTtsEnabled),
+              },
             ].map((option) => (
               <Pressable
                 key={option.key}
@@ -2227,8 +2251,58 @@ function AppShell({ storage }) {
             ))}
           </View>
           <Text style={[styles.mutedText, { color: colors.secondaryText }]}>
-            Turn spoken card audio and answer sound effects on or off independently.
+            Turn spoken card audio, answer sound effects, and automatic prompt playback on or off independently.
           </Text>
+        </View>
+
+        <View style={styles.settingsGroup}>
+          <Text style={[styles.settingsLabel, { color: colors.primaryText }]}>TTS volume</Text>
+          <View style={styles.quizSizeRow}>
+            {VOLUME_OPTIONS.map((value) => {
+              const active = ttsVolume === value;
+              return (
+                <Pressable
+                  key={`tts-volume-${value}`}
+                  style={[
+                    styles.quizSizeChip,
+                    { borderColor: colors.border },
+                    active && { backgroundColor: colors.primaryText, borderColor: colors.primaryText },
+                  ]}
+                  onPress={() => updateSpeechSetting('tts_volume', value, setTtsVolume)}
+                >
+                  <Text style={[styles.quizSizeText, { color: active ? colors.primaryButtonText : colors.primaryText }]}>
+                    {Math.round(value * 100)}%
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          <Text style={[styles.mutedText, { color: colors.secondaryText }]}>Manual previews and auto-play speech use this volume.</Text>
+        </View>
+
+        <View style={styles.settingsGroup}>
+          <Text style={[styles.settingsLabel, { color: colors.primaryText }]}>SFX volume</Text>
+          <View style={styles.quizSizeRow}>
+            {VOLUME_OPTIONS.map((value) => {
+              const active = sfxVolume === value;
+              return (
+                <Pressable
+                  key={`sfx-volume-${value}`}
+                  style={[
+                    styles.quizSizeChip,
+                    { borderColor: colors.border },
+                    active && { backgroundColor: colors.primaryText, borderColor: colors.primaryText },
+                  ]}
+                  onPress={() => updateSpeechSetting('sfx_volume', value, setSfxVolume)}
+                >
+                  <Text style={[styles.quizSizeText, { color: active ? colors.primaryButtonText : colors.primaryText }]}>
+                    {Math.round(value * 100)}%
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          <Text style={[styles.mutedText, { color: colors.secondaryText }]}>Correct and incorrect answer sounds use this volume.</Text>
         </View>
 
         <View style={styles.settingsGroup}>
@@ -2327,20 +2401,20 @@ function AppShell({ storage }) {
           </>
         )}
 
-        <Pressable
-          style={[
-            styles.secondaryButton,
-            {
-              backgroundColor: colors.surface,
-              borderColor: colors.border,
-              opacity: ttsEnabled ? 1 : 0.55,
-            },
-          ]}
-          onPress={() => speakFrontText(findSpeechPreviewText(cards))}
-          disabled={!ttsEnabled}
-        >
-          <Text style={[styles.secondaryButtonText, { color: colors.primaryText }]}>Preview speech</Text>
-        </Pressable>
+        {ttsEnabled ? (
+          <Pressable
+            style={[
+              styles.secondaryButton,
+              {
+                backgroundColor: colors.surface,
+                borderColor: colors.border,
+              },
+            ]}
+            onPress={() => speakFrontText(findSpeechPreviewText(cards))}
+          >
+            <Text style={[styles.secondaryButtonText, { color: colors.primaryText }]}>Preview speech</Text>
+          </Pressable>
+        ) : null}
       </View>
 
       <View style={[styles.sectionCard, { backgroundColor: colors.surface, borderColor: colors.border }]}>
@@ -2395,9 +2469,11 @@ function AppShell({ storage }) {
                   </Text>
                 ) : null}
               </View>
-              <Pressable style={[styles.listenMiniButton, { backgroundColor: colors.softAccent }]} onPress={() => speakFrontText(item.front)}>
-                <Text style={styles.listenMiniText}>🔊</Text>
-              </Pressable>
+              {ttsEnabled ? (
+                <Pressable style={[styles.listenMiniButton, { backgroundColor: colors.softAccent }]} onPress={() => speakFrontText(item.front)}>
+                  <Text style={styles.listenMiniText}>🔊</Text>
+                </Pressable>
+              ) : null}
             </View>
           ))
         )}

--- a/src/lib/audio.web.js
+++ b/src/lib/audio.web.js
@@ -7,6 +7,7 @@ export async function setAudioModeAsync() {}
 export function createAudioPlayer(source) {
   let audio = null;
   let audioSource = getAssetUri(source);
+  let volume = 1;
 
   const ensureAudio = () => {
     if (typeof window === 'undefined' || typeof window.Audio === 'undefined') {
@@ -17,6 +18,8 @@ export function createAudioPlayer(source) {
       audio = new window.Audio(audioSource || undefined);
       audio.preload = 'auto';
     }
+
+    audio.volume = volume;
 
     return audio;
   };
@@ -36,6 +39,15 @@ export function createAudioPlayer(source) {
     },
     pause() {
       audio?.pause();
+    },
+    set volume(value) {
+      volume = Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 1;
+      if (audio) {
+        audio.volume = volume;
+      }
+    },
+    get volume() {
+      return volume;
     },
     replace(nextSource) {
       audioSource = getAssetUri(nextSource);
@@ -75,6 +87,7 @@ export function useAudioPlayer(source) {
   const sourceNodeRef = useRef(null);
   const gainNodeRef = useRef(null);
   const seekOffsetRef = useRef(0);
+  const volumeRef = useRef(1);
   const assetUri = getAssetUri(source);
 
   useEffect(() => {
@@ -89,7 +102,7 @@ export function useAudioPlayer(source) {
 
     const context = new AudioContextClass();
     const gainNode = context.createGain();
-    gainNode.gain.value = FEEDBACK_GAIN;
+    gainNode.gain.value = FEEDBACK_GAIN * volumeRef.current;
     gainNode.connect(context.destination);
 
     audioContextRef.current = context;
@@ -174,6 +187,16 @@ export function useAudioPlayer(source) {
       },
       seekTo(seconds) {
         seekOffsetRef.current = Number(seconds) || 0;
+      },
+      set volume(value) {
+        const normalized = Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 1;
+        volumeRef.current = normalized;
+        if (gainNodeRef.current) {
+          gainNodeRef.current.gain.value = FEEDBACK_GAIN * normalized;
+        }
+      },
+      get volume() {
+        return volumeRef.current;
       },
     }),
     []

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -89,8 +89,8 @@ export async function saveQuizSession(db, selectedSetIds, answers) {
 
 export async function loadAppSettings(db, defaults) {
   const rows = await db.getAllAsync(
-    'SELECT key, value FROM app_settings WHERE key IN (?, ?, ?, ?, ?, ?, ?)',
-    ['tts_rate', 'tts_pitch', 'theme', 'tts_voice', 'tts_provider', 'tts_enabled', 'sfx_enabled']
+    'SELECT key, value FROM app_settings WHERE key IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    ['tts_rate', 'tts_pitch', 'theme', 'tts_voice', 'tts_provider', 'tts_enabled', 'tts_volume', 'sfx_enabled', 'sfx_volume', 'tts_autoplay_enabled']
   );
 
   const settingsMap = Object.fromEntries((rows ?? []).map((row) => [row.key, row.value]));
@@ -102,7 +102,10 @@ export async function loadAppSettings(db, defaults) {
     voice: settingsMap.tts_voice || defaults.voice,
     provider: settingsMap.tts_provider || defaults.provider,
     ttsEnabled: settingsMap.tts_enabled ? settingsMap.tts_enabled === 'true' : defaults.ttsEnabled,
+    ttsVolume: Number(settingsMap.tts_volume) || defaults.ttsVolume,
     sfxEnabled: settingsMap.sfx_enabled ? settingsMap.sfx_enabled === 'true' : defaults.sfxEnabled,
+    sfxVolume: Number(settingsMap.sfx_volume) || defaults.sfxVolume,
+    autoPlayTtsEnabled: settingsMap.tts_autoplay_enabled ? settingsMap.tts_autoplay_enabled === 'true' : defaults.autoPlayTtsEnabled,
   };
 }
 

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -414,7 +414,10 @@ export function createWebStorage() {
         voice: store.appSettings.tts_voice || defaults.voice,
         provider: store.appSettings.tts_provider || defaults.provider,
         ttsEnabled: store.appSettings.tts_enabled ? store.appSettings.tts_enabled === 'true' : defaults.ttsEnabled,
+        ttsVolume: Number(store.appSettings.tts_volume) || defaults.ttsVolume,
         sfxEnabled: store.appSettings.sfx_enabled ? store.appSettings.sfx_enabled === 'true' : defaults.sfxEnabled,
+        sfxVolume: Number(store.appSettings.sfx_volume) || defaults.sfxVolume,
+        autoPlayTtsEnabled: store.appSettings.tts_autoplay_enabled ? store.appSettings.tts_autoplay_enabled === 'true' : defaults.autoPlayTtsEnabled,
       };
     },
 

--- a/src/lib/tts.js
+++ b/src/lib/tts.js
@@ -294,7 +294,7 @@ export async function prefetchTts({ text, language, pitch, provider, rate, voice
   };
 }
 
-export async function speakWithTts({ text, language, pitch, provider, rate, voice }) {
+export async function speakWithTts({ text, language, pitch, provider, rate, voice, volume }) {
   if (provider === TTS_PROVIDER_GOOGLE && GOOGLE_TTS_PROXY_BASE_URL) {
     try {
       await stopTtsPlayback();
@@ -323,6 +323,9 @@ export async function speakWithTts({ text, language, pitch, provider, rate, voic
       }
 
       googlePlayer = createAudioPlayer(audioSource);
+      if (googlePlayer) {
+        googlePlayer.volume = Number.isFinite(volume) ? Math.max(0, Math.min(1, volume)) : 1;
+      }
       if (googlePlayer?.play) {
         await googlePlayer.play();
       }
@@ -340,7 +343,7 @@ export async function speakWithTts({ text, language, pitch, provider, rate, voic
         selectedLanguage: selectedLanguage || '',
       };
     } catch (error) {
-      await speakWithSystemTts({ text, language, pitch, rate, voice });
+      await speakWithSystemTts({ text, language, pitch, rate, voice, volume });
       return {
         provider,
         effectiveProvider: TTS_PROVIDER_SYSTEM,
@@ -356,7 +359,7 @@ export async function speakWithTts({ text, language, pitch, provider, rate, voic
     }
   }
 
-  await speakWithSystemTts({ text, language, pitch, rate, voice });
+  await speakWithSystemTts({ text, language, pitch, rate, voice, volume });
   return {
     provider,
     effectiveProvider: TTS_PROVIDER_SYSTEM,
@@ -401,13 +404,14 @@ async function listSystemVoices() {
   }
 }
 
-async function speakWithSystemTts({ text, language, pitch, rate, voice }) {
+async function speakWithSystemTts({ text, language, pitch, rate, voice, volume }) {
   Speech.stop();
   Speech.speak(text, {
     language,
     pitch,
     rate,
     voice: voice || undefined,
+    volume: Number.isFinite(volume) ? Math.max(0, Math.min(1, volume)) : 1,
   });
 }
 


### PR DESCRIPTION
### Motivation
- Provide per-type sound controls so users can toggle TTS and SFX independently and adjust their volumes. 
- Ensure automatic prompt playback can be enabled/disabled and that UI elements reflect TTS availability (hide sound buttons when TTS is off). 
- Persist new settings so preferences survive reloads on both native and web storage backends.

### Description
- Added new settings and state for `ttsVolume`, `sfxVolume`, and `autoPlayTtsEnabled` with sensible defaults and a `VOLUME_OPTIONS` selector in the Speech settings UI. 
- Persisted the new settings in storage and database loading paths so web and native storage return `ttsVolume`, `sfxVolume`, and `tts_autoplay_enabled`. 
- Applied configured volumes to playback: TTS calls now forward `volume` into `speakWithTts` (Google audio player and system TTS), feedback SFX players accept a runtime `volume`, and web audio helpers (`createAudioPlayer` and `useAudioPlayer`) were extended to support runtime volume getters/setters. 
- Updated UI behavior to hide/disable preview and per-option sound buttons when TTS is disabled and added an Auto-play TTS toggle and separate TTS/SFX volume pickers in the Speech settings.

### Testing
- Ran unit tests with `npm test -- --runInBand` and all test suites passed. 
- Performed a web export with `npx expo export --platform web` which completed and produced a `dist` export. 
- Attempted ESLint (`npx --yes eslint ...`) but it failed due to the repository not including an ESLint v9 config file, so linting was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf98a7a46883299fd72aec2ba23d6d)